### PR TITLE
Add better support for complex imput models like composition/ime/auto-correct/etc

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -207,6 +207,13 @@ class Content extends React.Component {
   updateSelection = () => {
     if (!this.ref.current) return
 
+    // While the editor is handling a composition (like for Asian input), we allow the browser to modify the DOM
+    // and we avoid modifying slate's internal representation of the document until the composition is over.
+    // Because of this the user might have typed a character at position 4, but slate thinks there is only
+    // 3 characters in the node!  So, the work around is to skip syncing slate's view of the selection to the DOM
+    // until the composition is over.
+    if (this.isComposing) return
+
     const { editor } = this.props
     const { value } = editor
     const { selection } = value
@@ -501,6 +508,9 @@ class Content extends React.Component {
         return
       }
     }
+
+    if (handler === 'onCompositionStart') this.isComposing = true
+    if (handler === 'onCompositionEnd') this.isComposing = false
 
     this.props.onEvent(handler, event)
   }

--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -12,17 +12,43 @@ import DATA_ATTRS from '../constants/data-attributes'
  * @type {Component}
  */
 
-const TextString = ({ text = '', isTrailing = false }) => {
-  return (
-    <span
-      {...{
-        [DATA_ATTRS.STRING]: true,
-      }}
-    >
-      {text}
-      {isTrailing ? '\n' : null}
-    </span>
-  )
+class TextString extends React.Component {
+  constructor(props) {
+    super(props)
+    this.ref = React.createRef()
+    // This component may have skipped rendering due to native operations being
+    // applied. If an undo is performed React will see the old and new shadow DOM
+    // match and not apply an update. Forces each render to actually reconcile.
+    this.forceUpdateFlag = false
+  }
+
+  shouldComponentUpdate(nextProps) {
+    // If a native operation has made the text content the same as what
+    // we are going to make it, skip. Maintains the native spell check handling.
+    return this.ref.current.textContent !== nextProps.children
+  }
+
+  componentDidMount() {
+    this.forceUpdateFlag = !this.forceUpdateFlag
+  }
+
+  componentDidUpdate() {
+    this.forceUpdateFlag = !this.forceUpdateFlag
+  }
+
+  render() {
+    return (
+      <span
+        key={this.forceUpdateFlag ? 'A' : 'B'}
+        ref={this.ref}
+        {...{
+          [DATA_ATTRS.STRING]: true,
+        }}
+      >
+        {this.props.children}
+      </span>
+    )
+  }
 }
 
 /**
@@ -101,9 +127,9 @@ const Leaf = props => {
     const isLastLeaf = index === leaves.size - 1
 
     if (isLastText && isLastLeaf && lastChar === '\n') {
-      children = <TextString isTrailing text={text} />
+      children = <TextString>{`${text}\n`}</TextString>
     } else {
-      children = <TextString text={text} />
+      children = <TextString>{text}</TextString>
     }
   }
 

--- a/packages/slate-react/src/components/leaf.js
+++ b/packages/slate-react/src/components/leaf.js
@@ -25,7 +25,35 @@ class TextString extends React.Component {
   shouldComponentUpdate(nextProps) {
     // If a native operation has made the text content the same as what
     // we are going to make it, skip. Maintains the native spell check handling.
-    return this.ref.current.textContent !== nextProps.children
+    const domNode = this.ref.current
+    const domTextContent = domNode.textContent
+    const reactTextContent = nextProps.children
+    if (domTextContent !== reactTextContent) return true
+
+    // If we should be a zero width node, but there is some text content in the dom, then allow react to clean it up
+    if (nextProps.isZeroWidth && domTextContent.replace(/[\uFEFF]/g, '') !== '')
+      return true
+
+    // Otherwise, we shouldn't have to touch the text node at all, we might need to strip the zero-width attributes though!
+    if (domNode.hasAttribute(DATA_ATTRS.ZERO_WIDTH)) {
+      domNode.removeAttribute(DATA_ATTRS.ZERO_WIDTH)
+    }
+
+    if (domNode.hasAttribute(DATA_ATTRS.LENGTH)) {
+      domNode.removeAttribute(DATA_ATTRS.LENGTH)
+    }
+
+    if (!domNode.hasAttribute(DATA_ATTRS.STRING)) {
+      domNode.setAttribute(DATA_ATTRS.STRING, 'true')
+    }
+
+    for (const child of domNode.childNodes) {
+      if (child.tagName === 'BR') {
+        domNode.removeChild(child)
+      }
+    }
+
+    return false
   }
 
   componentDidMount() {
@@ -37,38 +65,36 @@ class TextString extends React.Component {
   }
 
   render() {
-    return (
-      <span
-        key={this.forceUpdateFlag ? 'A' : 'B'}
-        ref={this.ref}
-        {...{
-          [DATA_ATTRS.STRING]: true,
-        }}
-      >
-        {this.props.children}
-      </span>
-    )
+    const { isZeroWidth, isLineBreak, length, children } = this.props
+
+    if (isZeroWidth) {
+      return (
+        <span
+          key={this.forceUpdateFlag ? 'A' : 'B'}
+          ref={this.ref}
+          {...{
+            [DATA_ATTRS.ZERO_WIDTH]: isLineBreak ? 'n' : 'z',
+            [DATA_ATTRS.LENGTH]: length || 0,
+          }}
+        >
+          {'\uFEFF'}
+          {isLineBreak ? <br /> : null}
+        </span>
+      )
+    } else {
+      return (
+        <span
+          key={this.forceUpdateFlag ? 'A' : 'B'}
+          ref={this.ref}
+          {...{
+            [DATA_ATTRS.STRING]: true,
+          }}
+        >
+          {children}
+        </span>
+      )
+    }
   }
-}
-
-/**
- * Leaf strings without text, render as zero-width strings.
- *
- * @type {Component}
- */
-
-const ZeroWidthString = ({ length = 0, isLineBreak = false }) => {
-  return (
-    <span
-      {...{
-        [DATA_ATTRS.ZERO_WIDTH]: isLineBreak ? 'n' : 'z',
-        [DATA_ATTRS.LENGTH]: length,
-      }}
-    >
-      {'\uFEFF'}
-      {isLineBreak ? <br /> : null}
-    </span>
-  )
 }
 
 /**
@@ -102,7 +128,7 @@ const Leaf = props => {
   if (editor.query('isVoid', parent)) {
     // COMPAT: Render text inside void nodes with a zero-width space.
     // So the node can contain selection but the text is not visible.
-    children = <ZeroWidthString length={parent.text.length} />
+    children = <TextString isZeroWidth length={parent.text.length} />
   } else if (
     text === '' &&
     parent.object === 'block' &&
@@ -112,12 +138,12 @@ const Leaf = props => {
     // COMPAT: If this is the last text node in an empty block, render a zero-
     // width space that will convert into a line break when copying and pasting
     // to support expected plain text.
-    children = <ZeroWidthString isLineBreak />
+    children = <TextString isZeroWidth isLineBreak />
   } else if (text === '') {
     // COMPAT: If the text is empty, it's because it's on the edge of an inline
     // node, so we render a zero-width space so that the selection can be
     // inserted next to it still.
-    children = <ZeroWidthString />
+    children = <TextString isZeroWidth />
   } else {
     // COMPAT: Browsers will collapse trailing new lines at the end of blocks,
     // so we need to add an extra trailing new lines to prevent that.

--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -8,6 +8,7 @@ import { IS_IOS, IS_IE, IS_EDGE } from 'slate-dev-environment'
 import cloneFragment from '../../utils/clone-fragment'
 import getEventTransfer from '../../utils/get-event-transfer'
 import setEventTransfer from '../../utils/set-event-transfer'
+import SELECTORS from '../../constants/selectors'
 
 /**
  * Debug.
@@ -38,16 +39,6 @@ function AfterPlugin(options = {}) {
 
   function onBeforeInput(event, editor, next) {
     const { value } = editor
-    const isSynthetic = !!event.nativeEvent
-
-    // If the event is synthetic, it's React's polyfill of `beforeinput` that
-    // isn't a true `beforeinput` event with meaningful information. It only
-    // gets triggered for character insertions, so we can just insert directly.
-    if (isSynthetic) {
-      event.preventDefault()
-      editor.insertText(event.data)
-      return next()
-    }
 
     // Otherwise, we can use the information in the `beforeinput` event to
     // figure out the exact change that will occur, and prevent it.
@@ -439,15 +430,6 @@ function AfterPlugin(options = {}) {
     const { document, selection } = value
     const { start } = selection
     const hasVoidParent = document.hasVoidParent(start.path, editor)
-
-    // COMPAT: In iOS, some of these hotkeys are handled in the
-    // `onNativeBeforeInput` handler of the `<Content>` component in order to
-    // preserve native autocorrect behavior, so they shouldn't be handled here.
-    if (Hotkeys.isSplitBlock(event) && !IS_IOS) {
-      return hasVoidParent
-        ? editor.moveToStartOfNextText()
-        : editor.splitBlock()
-    }
 
     if (Hotkeys.isDeleteBackward(event) && !IS_IOS) {
       return editor.deleteCharBackward()

--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -165,6 +165,7 @@ function BeforePlugin() {
 
     // Since we skipped all input events during the composition, once it is over
     // we need to manually call flush to sync the dom to the slate AST
+    saveCurrentNativeNode(editor)
     syncDomToSlateAst(editor)
 
     debug('onCompositionEnd', { event })
@@ -209,9 +210,9 @@ function BeforePlugin() {
       // erases selection as soon as composition starts and preventing <spans>
       // to be dropped.
       editor.delete()
-    } else {
-      saveCurrentNativeNode(editor)
     }
+
+    saveCurrentNativeNode(editor)
 
     debug('onCompositionStart', { event })
     next()

--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -773,21 +773,31 @@ function BeforePlugin() {
 
           // If there's only a single text node here, then we modify it's dom content directly
           // If there are multiple though, then it's a bit of an unknown situation, so we replace the entire span
-          if (stringNode.childNodes.length === 1) {
-            stringNode.childNodes[0].textContent = stringNode.childNodes[0].textContent.replace(
-              /[\uFEFF]/g,
-              ''
-            )
-          } else {
-            stringNode.textContent = stringNode.textContent.replace(
-              /[\uFEFF]/g,
-              ''
-            )
-          }
+          removeZeroWidths(stringNode)
 
           stringNode.removeAttribute(DATA_ATTRS.ZERO_WIDTH)
           stringNode.removeAttribute(DATA_ATTRS.LENGTH)
         }
+      }
+    }
+  }
+
+  function removeZeroWidths(parent) {
+    eachTextNode(parent, textNode => {
+      while (true) {
+        const pos = textNode.textContent.indexOf('\uFEFF')
+        if (pos === -1) break
+        textNode.deleteData(pos, 1)
+      }
+    })
+  }
+
+  function eachTextNode(node, cb) {
+    for (const child of node.childNodes) {
+      if (child.nodeType === 1) {
+        eachTextNode(child, cb)
+      } else if (child.nodeType === 3) {
+        cb(child)
       }
     }
   }

--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -68,7 +68,8 @@ function BeforePlugin() {
         editor.delete()
       }
 
-      const hasNewLines = event.data != null && event.data.indexOf('\n') >= 0
+      const inputText = (event.data || '').replace(/\n\r/g, '\n').replace(/\r/g, '\n')
+      const hasNewLines = inputText.indexOf('\n') >= 0
 
       if (isCollapsed && !hasNewLines) {
         saveCurrentNativeNode(editor)
@@ -78,7 +79,7 @@ function BeforePlugin() {
         if (!hasNewLines) {
           editor.insertText(event.data, null, false)
         } else {
-          const chunks = (event.data || '').split('\n')
+          const chunks = inputText.split('\n')
 
           chunks.map((text, i) => {
             if (text.length !== 0) {

--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -1,4 +1,5 @@
 import Debug from 'debug'
+import { Range } from 'slate'
 import Hotkeys from 'slate-hotkeys'
 import getWindow from 'get-window'
 import {
@@ -9,6 +10,7 @@ import {
 } from 'slate-dev-environment'
 
 import DATA_ATTRS from '../../constants/data-attributes'
+import SELECTORS from '../../constants/selectors'
 
 /**
  * Debug.
@@ -41,6 +43,10 @@ function BeforePlugin() {
    */
 
   function onBeforeInput(event, editor, next) {
+    // If the user has started a composition for something like a chinese character
+    // then wait to modify slate's AST and wait to force a react render until the composition is done.
+    if (isComposing) return
+
     const isSynthetic = !!event.nativeEvent
     if (editor.readOnly) return
     isUserActionPerformed = true
@@ -50,8 +56,45 @@ function BeforePlugin() {
     // allowing React's synthetic polyfill, so we need to ignore synthetics.
     if (isSynthetic && HAS_INPUT_EVENTS_LEVEL_2) return
 
-    debug('onBeforeInput', { event })
-    next()
+    // If the event is synthetic, it's React's polyfill of `beforeinput` that
+    // isn't a true `beforeinput` event with meaningful information. It only
+    // gets triggered for character insertions, so we can just insert directly.
+    // Single character inserts can be handled natively. Allows native rendering
+    // which preserves the native browser spell check handling.
+    if (isSynthetic) {
+      const isCollapsed = editor.value.selection.isCollapsed
+
+      if (!isCollapsed) {
+        editor.delete()
+      }
+
+      const hasNewLines = event.data != null && event.data.indexOf('\n') >= 0
+
+      if (isCollapsed && !hasNewLines) {
+        saveCurrentNativeNode(editor)
+      } else {
+        event.preventDefault()
+
+        if (!hasNewLines) {
+          editor.insertText(event.data, null, false)
+        } else {
+          const chunks = (event.data || '').split('\n')
+
+          chunks.map((text, i) => {
+            if (text.length !== 0) {
+              editor.insertText(text, null, false)
+            }
+
+            if (i !== chunks.length - 1) {
+              editor.splitBlock()
+            }
+          })
+        }
+      }
+    } else {
+      debug('onBeforeInput', { event })
+      next()
+    }
   }
 
   /**
@@ -115,6 +158,10 @@ function BeforePlugin() {
     const n = compositionCount
     isUserActionPerformed = true
 
+    // Since we skipped all input events during the composition, once it is over
+    // we need to manually call flush to sync the dom to the slate AST
+    syncDomToSlateAst(editor)
+
     // The `count` check here ensures that if another composition starts
     // before the timeout has closed out this one, we will abort unsetting the
     // `isComposing` flag, since a composition is still in affect.
@@ -166,6 +213,8 @@ function BeforePlugin() {
       // erases selection as soon as composition starts and preventing <spans>
       // to be dropped.
       editor.delete()
+    } else {
+      saveCurrentNativeNode(editor)
     }
 
     debug('onCompositionStart', { event })
@@ -376,6 +425,13 @@ function BeforePlugin() {
 
   function onInput(event, editor, next) {
     if (isComposing) return
+
+    // The input event fires after the browser has modified the dom
+    // At this point we can read the dom to see what the browser did and import that change into slate's AST
+    if (syncDomToSlateAst(editor)) {
+      return next()
+    }
+
     if (editor.value.selection.isBlurred) return
     isUserActionPerformed = true
     debug('onInput', { event })
@@ -415,7 +471,7 @@ function BeforePlugin() {
         Hotkeys.isDeleteWordForward(event) ||
         Hotkeys.isItalic(event) ||
         Hotkeys.isRedo(event) ||
-        Hotkeys.isSplitBlock(event) ||
+        // Hotkeys.isSplitBlock(event) ||
         Hotkeys.isTransposeCharacter(event) ||
         Hotkeys.isUndo(event))
     ) {
@@ -476,6 +532,193 @@ function BeforePlugin() {
   function clearUserActionPerformed() {
     isUserActionPerformed = false
     return null
+  }
+
+  /**
+   * The job of this function is to look at the dom, see what text is there, and sync that text into slate.
+   * We use this for things like asian language compositions, auto suggest/correct, and mac's accented character input.
+   * Each of these are too complicated to replicate perfectly with the events the browser exposes to us.  Additionally,
+   * the browser relies on us not modifying the text node.  If we touch the text node's content in any way, then the
+   * browser will abort any composition that it has in progress!  So our goal is to let the browser do its things,
+   * avoid touching it or syncing its state at all, and then once it is done, we will sync its state into slate,
+   * which is what this function does.
+   *
+   * A slate AST will look something like this:
+   * document: {
+   *   nodes: [{
+   *     type: 'line',
+   *     nodes: [{key: '42', type: 'text', text: '**foo**'}],
+   *   ]}
+   * }
+   *
+   * The corresponding dom structure will look something like:
+   * <span data-key=42>
+   *   <span decoration="syntax">
+   *     <span data-string=true>**</span>
+   *   </span>
+   *   <span decoration="bold">
+   *     <span data-string=true>foo</span>
+   *   </span>
+   *   <span decoration="syntax">
+   *     <span data-string=true>**</span>
+   *   </span>
+   * </span>
+   *
+   * The important thing to note about the above is that there is a single span tag that corresponds to each Text node
+   * in the AST.  Generally speaking, thatSpanNode.textContent === LeaftAstTextNode.text
+   *
+   * The part where that is not true is zero-width spaces.  Slate needs to force text nodes to be created, and it does
+   * this by creating dom nodes that just have a zero width space in them.  The problem with this is the browser doesn't
+   * know that we don't want them.  So when a user types "a" to start, they will only see one character, but in the dom
+   * there are actually two (because the browser didn't remove the zero-width space).  So, we have to do some surgery
+   * on the dom to clean these up and keep them out of the slate AST.
+   */
+
+  function syncDomToSlateAst(editor) {
+    const { nextNativeOperation } = editor.controller.tmp
+    if (!nextNativeOperation) return false
+    editor.controller.tmp.nextNativeOperation = null
+
+    const {
+      slateSelection: oldSlateSelection,
+      slateDomSpan,
+    } = nextNativeOperation
+    const {
+      anchorNode: textNode,
+      anchorOffset: currentOffset,
+    } = window.getSelection()
+
+    // Sanity checks:
+    // - Ensure that the currently selected text node is in the dom and has a valid root slate span
+    // - Ensure that that span is the same one as what we saved earlier.  If it's not, then we might not
+    //   be able to map the changes we see in the dom back into the slate AST
+    const currentSlateDomSpan = textNode.parentElement.closest(SELECTORS.KEY)
+    if (currentSlateDomSpan == null)
+      throw Error('YOWIE WOWIE: could not find slate span')
+    if (slateDomSpan !== currentSlateDomSpan)
+      throw Error('YOWIE WOWIE: slate span node mismatch')
+
+    const key = oldSlateSelection.anchor.key
+    const path = editor.value.document.getPath(key)
+    const slateAstNode = editor.value.document.getNode(key)
+
+    sanitizeZeroWidthSpaces(editor, slateDomSpan)
+
+    // Now grab the full current text content of the slate dom node that represents the full slate AST node
+    // We do need to strip any zero-width spaces though, since slate uses them for decorations and other things,
+    // so they might legitimately need to be in the dom, but should never be in the AST
+    const newTextContent = slateDomSpan.textContent.replace(/[\uFEFF]/g, '')
+
+    editor.insertTextAtRange(
+      Range.create({
+        anchor: { path, key, offset: 0 },
+        focus: { path, key, offset: slateAstNode.text.length },
+      }),
+      newTextContent
+    )
+
+    // If the textNode is no longer in the dom, then something has gone very wrong with the insert operation
+    // on the previous line:
+    if (textNode.parentElement == null)
+      throw Error('YOWIE WOWIE: text node is no longer in the dom!')
+
+    // Now we need to go and update the selection.  First, we modify slate's internal representation of the selection:
+    const newSelectionPosition = Math.min(
+      textNode.textContent.length,
+      currentOffset
+    )
+    // This maps a dom position to a slate position.  Remember above: A single slate node will have lots of child
+    // dom nodes, which means the dom offset is usually going to be much different from what the offset is in the slate
+    // AST
+    const point = editor.findPoint(textNode, newSelectionPosition)
+    if (point == null)
+      throw Error(
+        'YOWIE WOWIE: Unable to translate dom position to slate position!'
+      )
+    editor.select(Range.create({ anchor: point, focus: point }))
+
+    // There's a good chance that slate will do nothing with the update above, partly because we have disabled selection
+    // updates in some cases.  So, let's also force the browser to move the selection to where we want.
+    // (IIRC in some cases slate was also moving the selection back to an old place sometimes, so this fixes that too).
+    window.getSelection().collapse(textNode, newSelectionPosition)
+  }
+
+  /**
+   * Slate has two dom representations for leaf nodes:
+   * <span data-string=true>abc</span>
+   * <span data-zero-width=true></span>
+   * When a node is first created, it starts as the zero-width dom node.  When we let the browser modify it, we will
+   * be left with the zero-width markup, but it now contains more than just a zero-width string.  So, in this case,
+   * we want to strip those attributes.
+   * Additionally, if a node contains anything more than just a zero width string, then we should remove any zero-width
+   * spaces from it if has any.
+   */
+
+  function sanitizeZeroWidthSpaces(editor, slateDomSpan) {
+    const allChildTextNodes = slateDomSpan.querySelectorAll(
+      `${SELECTORS.STRING}, ${SELECTORS.ZERO_WIDTH}`
+    )
+
+    for (const stringNode of allChildTextNodes) {
+      const isStringNode = stringNode.hasAttribute(DATA_ATTRS.STRING)
+      const isZeroWidth = stringNode.hasAttribute(DATA_ATTRS.ZERO_WIDTH)
+
+      // This should basically always be true:
+      if (isStringNode || isZeroWidth) {
+        const hasZeroWidthChars = stringNode.textContent.indexOf('\uFEFF') >= 0
+
+        // A string node with any zero width characters needs to be cleaned
+        // A zero width node with only a zero width character is ok though:
+        if (
+          (isStringNode && hasZeroWidthChars) ||
+          (isZeroWidth && stringNode.textContent !== '\uFEFF')
+        ) {
+          // Oof, sometimes slate adds empty br tags to the dom (see leaf.js), which leads to the code later getting
+          // messed up :(  In this case though, we know the node _shouldn't_ have any, because it must have some
+          // non-zero-width content, so we can just remove them.
+          for (const childNode of stringNode.childNodes) {
+            if (childNode.nodeType === 1 && childNode.tagName === 'BR') {
+              stringNode.removeChild(childNode)
+            }
+          }
+
+          // If there's only a single text node here, then we modify it's dom content directly
+          // If there are multiple though, then it's a bit of an unknown situation, so we replace the entire span
+          if (stringNode.childNodes.length === 1) {
+            stringNode.childNodes[0].textContent = stringNode.childNodes[0].textContent.replace(
+              /[\uFEFF]/g,
+              ''
+            )
+          } else {
+            stringNode.textContent = stringNode.textContent.replace(
+              /[\uFEFF]/g,
+              ''
+            )
+          }
+
+          stringNode.removeAttribute(DATA_ATTRS.ZERO_WIDTH)
+          stringNode.removeAttribute(DATA_ATTRS.LENGTH)
+        }
+      }
+    }
+  }
+
+  function saveCurrentNativeNode(editor) {
+    if (editor.controller.tmp.nextNativeOperation) {
+      throw Error('YOWIE WOWIE: already have a native op!')
+    }
+
+    // Save a reference to the currently selected AST node, and the current selection
+    // Once the browser has modified the dom, we'll use these to figure out what changes were made
+    editor.controller.tmp.nextNativeOperation = {
+      slateSelection: editor.value.selection,
+      // The node with a data-key property entirely encompasses a single slate AST text node.
+      // It'll have lots of children for the various decorations, but its entire textContent should map
+      // to a single AST node
+      slateDomSpan: window
+        .getSelection()
+        .anchorNode.parentElement.closest(SELECTORS.KEY),
+    }
   }
 
   /**

--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -36,14 +36,21 @@ function CommandsPlugin() {
     }
 
     // If the text is no different, abort.
-    if (text === domText) return
+    // Ignore all zero-width spaces here.  There will definitely be some in the dom
+    // and we don't want those to make slate thing that the dom does not match the slate AST:
+    if (text.replace(/[\uFEFF]/g, '') === domText.replace(/[\uFEFF]/g, ''))
+      return
 
     let entire = selection.moveAnchorTo(path, 0).moveFocusTo(path, text.length)
 
     entire = document.resolveRange(entire)
 
     // Change the current value to have the leaf's text replaced.
-    editor.insertTextAtRange(entire, domText, node.marks)
+    editor.insertTextAtRange(
+      entire,
+      domText.replace(/[\uFEFF]/g, ''),
+      node.marks
+    )
     return
   }
 

--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -1,3 +1,5 @@
+import { Block } from 'slate'
+
 /**
  * A set of commands for the React plugin.
  *
@@ -63,9 +65,36 @@ function CommandsPlugin() {
    */
 
   function reconcileDOMNode(editor, domNode) {
-    const domElement = domNode.parentElement.closest('[data-key]')
-    const node = editor.findNode(domElement)
-    editor.reconcileNode(node)
+    try {
+      const domElement = domNode.parentElement.closest('[data-key]')
+      const node = editor.findNode(domElement)
+      editor.reconcileNode(node)
+    } catch (e) {
+      console.error(e)
+
+      // Woo!  So, if we get here, something has gone horribly wrong and the browser has modified the dom in a way
+      // that slate can no longer understand.  So, in this event, we are going to replace the entire line (which changes
+      // the react key and forces react to re-build the dom), and this will get everything back into a working state
+      // hopefully.
+      const domElement =
+        domNode.hasAttribute && domNode.hasAttribute('data-key')
+          ? domNode
+          : domNode.parentElement.closest('[data-key]')
+      if (domElement == null) return
+
+      const slateNode = editor.value.document.getChild(
+        domNode.getAttribute('data-key')
+      )
+      if (slateNode == null) return
+
+      const blockNode =
+        slateNode.object === 'block'
+          ? slateNode
+          : editor.value.document.getClosestBlock(slateNode.key)
+      if (blockNode == null) return
+
+      editor.replaceNodeByKey(blockNode.key, Block.create(blockNode.toJSON()))
+    }
   }
 
   return {

--- a/packages/slate-react/src/utils/find-dom-node.js
+++ b/packages/slate-react/src/utils/find-dom-node.js
@@ -12,10 +12,10 @@ import DATA_ATTRS from '../constants/data-attributes'
  */
 
 function findDOMNode(key, win = window) {
-  warning(
-    false,
-    'As of slate-react@0.22 the `findDOMNode(key)` helper is deprecated in favor of `editor.findDOMNode(path)`.'
-  )
+  // warning(
+  //   false,
+  //   'As of slate-react@0.22 the `findDOMNode(key)` helper is deprecated in favor of `editor.findDOMNode(path)`.'
+  // )
 
   if (Node.isNode(key)) {
     key = key.key

--- a/packages/slate-react/src/utils/safely-get-parent-key-node.js
+++ b/packages/slate-react/src/utils/safely-get-parent-key-node.js
@@ -1,0 +1,9 @@
+import SELECTORS from '../constants/selectors'
+
+export default function safelyGetParentKeyNode(node) {
+  if (node == null) return null
+
+  if (node.closest == null) node = node.parentElement
+  if (node.hasAttribute(SELECTORS.KEY)) return node
+  return node.closest(SELECTORS.KEY)
+}

--- a/packages/slate-react/src/utils/sanitize-dom-on-error.js
+++ b/packages/slate-react/src/utils/sanitize-dom-on-error.js
@@ -1,0 +1,30 @@
+import { Block } from 'slate'
+import safelyGetParentKeyNode from './safely-get-parent-key-node'
+import DATA_ATTRS from '../constants/data-attributes'
+
+export default function sanitizeDomOnError(editor, domNode, fn) {
+  try {
+    return fn()
+  } catch (e) {
+    console.warn('Safely handling caught error, reconciling dom', e)
+
+    // Woo!  So, if we get here, something has gone horribly wrong and the browser has modified the dom in a way
+    // that slate can no longer understand.  So, in this event, we are going to replace the entire line (which changes
+    // the react key and forces react to re-build the dom), and this will get everything back into a working state
+    // hopefully.
+    const domElement = safelyGetParentKeyNode(domNode)
+    if (domElement == null) return
+
+    const key = domElement.getAttribute(DATA_ATTRS.KEY)
+    const slateNode = editor.value.document.getNode(key)
+    if (slateNode == null) return
+
+    const blockNode =
+      slateNode.object === 'block'
+        ? slateNode
+        : editor.value.document.getClosestBlock(slateNode.key)
+    if (blockNode == null) return
+
+    editor.replaceNodeByKey(blockNode.key, Block.create(blockNode.toJSON()))
+  }
+}

--- a/packages/slate/src/commands/on-history.js
+++ b/packages/slate/src/commands/on-history.js
@@ -17,6 +17,8 @@ const Commands = {}
  */
 
 Commands.save = (editor, operation) => {
+  // Disabled for performance (saves ~1-5ms), since we don't use slate's undo code at all right now
+  return
   const { operations, value } = editor
   const { data } = value
   let { save, merge } = editor.tmp

--- a/packages/slate/src/controllers/editor.js
+++ b/packages/slate/src/controllers/editor.js
@@ -56,6 +56,7 @@ class Editor {
       merge: null,
       normalize: true,
       save: true,
+      nextNativeOperation: null,
     }
 
     const core = CorePlugin({ plugins })


### PR DESCRIPTION
Uses a similar model to editors like etherpad, which let the browser modify the dom, and then incorporates any changes in the browser into the editor's internal data structure.

The before.js plugin has most of the documentation, so I'd probably start there when reading.  I'm also happy to sit down with you in person to go through this one.