### PR TITLE
Render inline children

### DIFF
--- a/packages/slate-react/src/components/block.js
+++ b/packages/slate-react/src/components/block.js
@@ -101,7 +101,7 @@ export default class Block extends React.Component {
  * @return {Range}
  */
 
-function getRelativeRange(node, index, range) {
+export function getRelativeRange(node, index, range) {
   if (range.isUnset) {
     return null
   }

--- a/packages/slate-react/src/components/inline.js
+++ b/packages/slate-react/src/components/inline.js
@@ -1,8 +1,11 @@
 import React from 'react'
+import { getRelativeRange } from './block'
 
+import Text from './text'
 import DATA_ATTRS from '../constants/data-attributes'
 
 export default class Inline extends React.Component {
+  tmp = { nodeRefs: {} }
   ref = React.createRef()
 
   shouldComponentUpdate(nextProps) {
@@ -11,6 +14,58 @@ export default class Inline extends React.Component {
 
   render() {
     const { editor, node, parent } = this.props
+
+    const decorations = node.getDecorations(editor)
+    const children = []
+
+    if (
+      node.nodes.length > 1 ||
+      (node.nodes.length === 1 && node.nodes.first().text !== ' ')
+    ) {
+      for (const child of node.nodes) {
+        const i = children.length
+
+        const refFn = ref => {
+          if (ref) {
+            this.tmp.nodeRefs[i] = ref
+          } else {
+            delete this.tmp.nodeRefs[i]
+          }
+        }
+
+        if (child.object === 'inline') {
+          const decs = decorations
+            .map(d => getRelativeRange(node, i, d))
+            .filter(d => d)
+
+          children.push(
+            <Inline
+              ref={refFn}
+              key={child.key}
+              editor={editor}
+              node={child}
+              parent={node}
+              decorations={decs}
+            />
+          )
+        } else {
+          const decs = decorations
+            .map(d => getRelativeRange(node, i, d))
+            .filter(d => d)
+
+          children.push(
+            <Text
+              ref={refFn}
+              key={child.key}
+              editor={editor}
+              node={child}
+              parent={node}
+              decorations={decs}
+            />
+          )
+        }
+      }
+    }
 
     // Attributes that the developer must mix into the element in their
     // custom node renderer component.
@@ -22,6 +77,7 @@ export default class Inline extends React.Component {
 
     return editor.run('renderInline', {
       attributes,
+      children,
       editor,
       node,
       parent,

--- a/packages/slate-react/src/components/inline.js
+++ b/packages/slate-react/src/components/inline.js
@@ -34,10 +34,6 @@ export default class Inline extends React.Component {
         }
 
         if (child.object === 'inline') {
-          const decs = decorations
-            .map(d => getRelativeRange(node, i, d))
-            .filter(d => d)
-
           children.push(
             <Inline
               ref={refFn}
@@ -45,7 +41,6 @@ export default class Inline extends React.Component {
               editor={editor}
               node={child}
               parent={node}
-              decorations={decs}
             />
           )
         } else {


### PR DESCRIPTION
This is almost a direct copy of the block children renderer, with an extra check for whether this inline's children is interesting at all (contains something more than just a space text node)