### PR TITLE
Fix iterable length warnings with inline children

### DIFF
--- a/packages/slate-react/src/components/inline.js
+++ b/packages/slate-react/src/components/inline.js
@@ -19,8 +19,8 @@ export default class Inline extends React.Component {
     const children = []
 
     if (
-      node.nodes.length > 1 ||
-      (node.nodes.length === 1 && node.nodes.first().text !== ' ')
+      node.nodes.size > 1 ||
+      (node.nodes.size === 1 && node.nodes.first().text !== ' ')
     ) {
       for (const child of node.nodes) {
         const i = children.length


### PR DESCRIPTION
RIP